### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,20 @@ To run:
    ```
    pip install -r requirements.txt -t lib
    ```
-3. Run this project locally from the command line:
+   
+3. Set the flask environmental variable:
+
+   ```
+   export FLASK_APP=app.py
+   ```
+
+4. Run this project locally from the command line:
 
    ```
    flask run
    ```
 
-4. Visit the application [http://localhost:5000](http://localhost:5000)
+5. Visit the application [http://localhost:5000](http://localhost:5000)
 
 
 ## Importing idyll-embed


### PR DESCRIPTION
This adds the step of setting the `FLASK_APP` environmental variable. I tried running it without that and got an error:

```
Error: Could not locate Flask application. You did not provide the FLASK_APP environment variable.
```